### PR TITLE
CSP: Allow embedded SVG+XML 

### DIFF
--- a/roles/starfitweb/files/html/header.py
+++ b/roles/starfitweb/files/html/header.py
@@ -1,4 +1,7 @@
 def http():
     print("Content-Type: text/html; charset=UTF-8")
     print('Cache-Control: "no-cache, no-store, must-revalidate"')
+    print(
+        "Content-Security-Policy: default-src https:; object-src 'self' data:; img-src 'self' data:"
+    )
     print()

--- a/roles/starfitweb/files/html/header.py
+++ b/roles/starfitweb/files/html/header.py
@@ -2,6 +2,6 @@ def http():
     print("Content-Type: text/html; charset=UTF-8")
     print('Cache-Control: "no-cache, no-store, must-revalidate"')
     print(
-        "Content-Security-Policy: default-src https:; object-src 'self' data:; img-src 'self' data:"
+        "Content-Security-Policy: default-src https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;"
     )
     print()

--- a/roles/starfitweb/files/html/templates/head.html
+++ b/roles/starfitweb/files/html/templates/head.html
@@ -1,4 +1,3 @@
-<meta http-equiv="Content-Security-Policy" content="default-src https:; object-src 'self' data:; img-src 'self' data:">
 <title>StarFit&trade;</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link href='https://fonts.googleapis.com/css?family=Exo+2:300,100' rel='stylesheet' type='text/css'>

--- a/roles/starfitweb/files/html/templates/home.html
+++ b/roles/starfitweb/files/html/templates/home.html
@@ -161,7 +161,6 @@
                     <select name="plotformat">
                         <option value="png" checked="checked">PNG</option>
                         <option value="svg">SVG</option>
-                        <option value="jpg">JPG</option>
                         <option value="pdf">PDF</option>
                     </select>
                 </td>


### PR DESCRIPTION
fixes #12 

- Move CSP into actual header
- Fix SVG embedding
- Remove JPG option (was broken anyway) because it's not a commonly used raster format for plots - PNG should be used if a raster is desired. And it seems MPL is not outputting a JPG even when we're asking for it.